### PR TITLE
Created alternate function

### DIFF
--- a/Triggering-Lambda-from-SQS/sqs_lambda_function.py
+++ b/Triggering-Lambda-from-SQS/sqs_lambda_function.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+import json
+import os
+import boto3
+
+DYNAMODB_TABLE = os.environ['DYNAMODB_TABLE']
+
+dynamodb = boto3.resource('dynamodb')
+
+def lambda_handler(event, context):
+    # Count items in the Lambda event 
+    no_messages = str(len(event['Records']))
+    print("Found " +no_messages +" messages to process.")
+
+    for message in event['Records']:
+
+        print(message)
+
+        # Write message to DynamoDB
+        table = dynamodb.Table(DYNAMODB_TABLE)
+
+        response = table.put_item(
+            Item={
+                'MessageId': message['messageId'],
+                'Body': message['body'],
+                'Timestamp': datetime.now().isoformat()
+            }
+        )
+        print("Wrote message to DynamoDB:", json.dumps(response))


### PR DESCRIPTION
Existing function does not leverage the SQS messages in the lambda event and instead polls the queue again, meaning once function gets up to speed with concurrent invocations, the queue is perpetually empty: only 5-7 messages make it into DynamoDB, then no more. This fix instead uses the Lambda event to push messages into DynamoDB.